### PR TITLE
Feature/db performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ Before starting the steps below, be sure you have [Git](https://www.linode.com/d
 - Twitter: [@tresorsawasawa](https://twitter.com/TresorSawasawa)
 - LinkedIn: [Trésor Sawasawa](https://www.linkedin.com/in/tresor-sawasawa/)
 
+👤 **Vahan Khachvankian**
+
+- GitHub: [@githubhandle](https://github.com/Gegardus)
+- Twitter: [@twitterhandle](https://twitter.com/Gegardus)
+
 ## :handshake: Contributing
 
 Feel free to check the [issues page](https://github.com/tresorsawasawa/Vet-clinic-database/issues)

--- a/data.sql
+++ b/data.sql
@@ -93,3 +93,10 @@ VALUES(1, 1, '2020-05-24'),
       (9, 2, '2020-08-03'),
       (10, 3, '2020-05-24'),
       (10, 1, '2021-01-11');
+
+
+-- This will add 3.594.280 visits considering you have 10 animals, 4 vets, and it will use around ~87.000 timestamps (~4min approx.)
+INSERT INTO visits (animal_id, vet_id, date_of_visit) SELECT * FROM (SELECT id FROM animals) animal_ids, (SELECT id FROM vets) vets_ids, generate_series('1980-01-01'::timestamp, '2021-01-01', '4 hours') visit_timestamp;
+
+-- This will add 2.500.000 owners with full_name = 'Owner <X>' and email = 'owner_<X>@email.com' (~2min approx.)
+INSERT INTO owners (full_name, email) select 'Owner ' || generate_series(1,2500000), 'owner_' || generate_series(1,2500000) || '@mail.com';

--- a/schema.sql
+++ b/schema.sql
@@ -99,3 +99,8 @@ ALTER TABLE owners ADD COLUMN email VARCHAR(120);
 -- Create INDEXES in the 'visits' table
 CREATE INDEX visits_animals_id_asc ON visits(animals_id ASC);
 CREATE INDEX visits_vets_id_asc ON visits(vets_id ASC);
+
+
+-- Create INDEXES in the 'owners' table
+CREATE INDEX owners_email_asc ON owners(email ASC);
+CREATE INDEX owners_name_asc ON owners(full_name ASC);

--- a/schema.sql
+++ b/schema.sql
@@ -92,3 +92,6 @@ CREATE TABLE visits(
   FOREIGN KEY (animals_id) REFERENCES animals (id) ON DELETE RESTRICT ON UPDATE CASCADE,
 	FOREIGN KEY (vets_id) REFERENCES vets (id) ON DELETE RESTRICT ON UPDATE CASCADE
 );
+
+/*-- Add an email column to your owners table ---*/
+ALTER TABLE owners ADD COLUMN email VARCHAR(120);

--- a/schema.sql
+++ b/schema.sql
@@ -95,3 +95,7 @@ CREATE TABLE visits(
 
 /*-- Add an email column to your owners table ---*/
 ALTER TABLE owners ADD COLUMN email VARCHAR(120);
+
+-- Create INDEXES in the 'visits' table
+CREATE INDEX visits_animals_id_asc ON visits(animals_id ASC);
+CREATE INDEX visits_vets_id_asc ON visits(vets_id ASC);


### PR DESCRIPTION
In this PR we completed the following tasks:
- [ ] Adde an `email` column to the `owners` table.
- [ ] Added [data](https://github.com/microverseinc/curriculum-databases/blob/main/db-structure/vet_clinic_performance_audit.md#:~:text=Run%20the%20following%20statements,generate_series(1%2C2500000)%20%7C%7C%20%27%40mail.com%27%3B) to my database.
- [ ] Used `EXPLAIN ANALYZE SELECT COUNT(*) FROM visits where animals_id = 4;` and find the following result:
![visits_animals_id_before_Perf](https://user-images.githubusercontent.com/83042742/161783417-bf9fe6d6-196b-4f9a-83f0-edc44ae9f761.png)
- [ ] Found a way to decrease the execution time of the query above :arrow_up: and found the following result:
![visits_animals_ids_AFTER](https://user-images.githubusercontent.com/83042742/161786025-fba93ae6-f2a6-4371-bb8d-06c43f5d9525.png)
- [ ] Improved execution time of the `EXPLAIN ANALYZE SELECT * FROM visits where vets_id = 2;` query with the result below:
![visits_vets_id_before](https://user-images.githubusercontent.com/83042742/161786846-92002533-598c-4f85-8bac-a23150596320.png)
- [ ] Result after improving:
![visits_vets_id_after](https://user-images.githubusercontent.com/83042742/161787017-c557fae3-f19f-41ee-93e5-bbcc097995b1.png)
- [ ] Improved execution time of the  `EXPLAIN ANALYZE SELECT * FROM owners where email = 'owner_18327@mail.com';
` query with the result below:
![Before_Owner_email_Perf](https://user-images.githubusercontent.com/83042742/161787583-abaf0dcd-95fb-4518-8d11-85a3127cd3c6.png)
- [ ] Result after improving:
![After_Perf_Owners_email](https://user-images.githubusercontent.com/83042742/161787724-09f7ed52-9794-4163-abf3-f87f4d2c2bc1.png)

